### PR TITLE
chore: Changed `Bloomfilter<String>` to `hashbrown::HashSet<Vec<u8>>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
@@ -240,6 +258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +428,7 @@ dependencies = [
  "clap",
  "env_logger",
  "fxhash",
+ "hashbrown",
  "kdam",
  "log",
  "memmap",
@@ -489,6 +518,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -710,3 +745,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bloomfilter = "1.0.14"
 clap = { version = "4.5.5", features = ["derive"] }
 env_logger = "0.11.5"
 fxhash = "0.2.1"
+hashbrown = "0.14.5"
 kdam = { version = "0.5.2", optional = true }
 log = { version = "0.4.22", features = ["release_max_level_warn", "std"] }
 memmap = "0.7.0"

--- a/src/parse/config.rs
+++ b/src/parse/config.rs
@@ -20,4 +20,4 @@ pub const INDEX_LENGTH: usize = 3;
 pub const INDEX_DEPTH: usize = 1;
 
 /// The maximum buffer size for each index file.
-pub const MAX_INDEX_BUFFER_SIZE: usize = 2_usize.pow(16);
+pub const MAX_INDEX_BUFFER_SIZE: usize = 2_usize.pow(12);

--- a/src/parse/models/index_collection.rs
+++ b/src/parse/models/index_collection.rs
@@ -25,8 +25,8 @@ impl<const LENGTH: usize, const DEPTH: usize, const MAX_SIZE: usize>
     }
 
     /// Add an item to the collection.
-    pub fn add(&self, item: &str) -> io::Result<()> {
-        let mut indices = indices_of::<LENGTH, DEPTH>(item);
+    pub fn add(&self, item: Vec<u8>) -> io::Result<()> {
+        let mut indices = indices_of::<LENGTH, DEPTH>(&item);
 
         indices
         .try_for_each(


### PR DESCRIPTION
Specifically, using `fxhash::FxHasher32` on `Vec<u8>`; this

- prevents strings containing non-ASCII characters to be skipped entirely. They will now be treated as '0'.
- removes the posibility of false positives, which inevitably will happen on very large data sets such as `rockyou2024.txt`.

The choice of 32 bit hash is to reduce memory usage and computation overhead. It is still slower than Bloomfilter, but the trade off is useful.