### PR TITLE
feat: LRU Cache implemented on the Rust side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "rayon",
 ]
 
 [[package]]
@@ -321,6 +322,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "memchr"
@@ -431,6 +441,7 @@ dependencies = [
  "hashbrown",
  "kdam",
  "log",
+ "lru",
  "memmap",
  "rayon",
  "reader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,13 @@ path = "src/parse/lib.rs"
 default = ["progress", "search"]
 progress = ["dep:kdam"]
 search = ["aho-corasick", "regex"]
+# This is only useful when the `IndexCollection` persists between searches,
+# which is not the case for FFI.
+search_lru = ["search", "lru"]
 skip_index_write = []
 aho-corasick = ["dep:aho-corasick"]
 regex = ["dep:regex"]
+lru = ["dep:lru"]
 
 [dependencies]
 aho-corasick = { version = "1.1.3", optional = true }
@@ -26,9 +30,10 @@ bloomfilter = "1.0.14"
 clap = { version = "4.5.5", features = ["derive"] }
 env_logger = "0.11.5"
 fxhash = "0.2.1"
-hashbrown = "0.14.5"
+hashbrown = { version = "0.14.5", features = ["rayon"] }
 kdam = { version = "0.5.2", optional = true }
 log = { version = "0.4.22", features = ["release_max_level_warn", "std"] }
+lru = { version = "0.12.4", optional = true }
 memmap = "0.7.0"
 rayon = "1.10.0"
 reader = {"path"="./crates/reader"}

--- a/crates/parse-ffi/Cargo.lock
+++ b/crates/parse-ffi/Cargo.lock
@@ -265,6 +265,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "rayon",
 ]
 
 [[package]]
@@ -321,6 +322,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "memchr"
@@ -440,6 +450,7 @@ dependencies = [
  "hashbrown",
  "kdam",
  "log",
+ "lru",
  "memmap",
  "rayon",
  "reader",

--- a/crates/parse-ffi/src/lib.rs
+++ b/crates/parse-ffi/src/lib.rs
@@ -184,6 +184,6 @@ pub unsafe extern "C" fn find_lines_in_index_collection(
         search_style,
     );
 
-    vec_str_to_mut_mut_c_char!(found)
+    vec_str_to_mut_mut_c_char!(<rockyou2024::models::IndexCollectionResult as Clone>::clone(&found))
 
 }

--- a/src/parse/config.rs
+++ b/src/parse/config.rs
@@ -30,6 +30,9 @@ pub const DEFAULT_MAX_BUFFER: usize = crate::config::MAX_INDEX_BUFFER_SIZE;
 /// but rather a corrupted line or bad data interpreted as passwords.
 pub const MAX_LINE_LENGTH: usize = 256;
 
+/// The default cache size.
+pub const CACHE_SIZE: usize = 1024;
+
 #[cfg(test)]
 #[cfg(not(feature = "skip_index_write"))]
 pub(crate) const TEST_DIR: &str = "./.tests";

--- a/src/parse/search/implementations/index_collection.rs
+++ b/src/parse/search/implementations/index_collection.rs
@@ -3,20 +3,56 @@
 
 use super::super::SearchStyle;
 use crate::{
-    models::{indices_of, IndexCollection, IndexFile},
+    models::{indices_of, IndexCollection, IndexCollectionResult, IndexFile},
     path_for_key,
 };
 use hashbrown::HashSet;
 use rayon::prelude::*;
 use std::io;
 
+#[cfg(feature = "lru")]
+use std::sync::{Arc, RwLock, RwLockWriteGuard};
+
+#[cfg(feature = "lru")]
+use crate::models::IndexCollectionCache;
+
+#[cfg(feature = "lru")]
+use crate::config::CACHE_SIZE;
+
 const LOG_TARGET: &str = "IndexCollection::search_for";
 
-impl<const LENGTH: usize, const DEPTH: usize> IndexCollection<LENGTH, DEPTH> {
+#[cfg(feature = "lru")]
+pub type IndexCollectionReturn = Arc<IndexCollectionResult>;
+
+#[cfg(not(feature = "lru"))]
+pub type IndexCollectionReturn = IndexCollectionResult;
+
+#[cfg(feature = "lru")]
+fn reset_cache_on_poisoned(
+    cache: &RwLock<IndexCollectionCache>,
+    err: &mut std::sync::PoisonError<RwLockWriteGuard<'_, IndexCollectionCache>>,
+) -> Option<Arc<IndexCollectionResult>> {
+    crate::error!(
+        target: LOG_TARGET,
+        "Failed to acquire lock on cache; cache might be poisoned: {err:?}. Resetting cache...",
+        err = err
+    );
+    **err.get_mut() = lru::LruCache::new(std::num::NonZeroUsize::new(CACHE_SIZE).expect(
+        "Failed to create a non-zero usize from the cache size; this should be unreachable.",
+    ));
+    cache.clear_poison();
+
+    // Cache is now empty, so we can just return None.
+    None
+}
+
+impl<const LENGTH: usize, const DEPTH: usize, const MAX_BUFFER: usize>
+    IndexCollection<LENGTH, DEPTH, MAX_BUFFER>
+{
     /// Search for a string in the index.
     ///
     /// This will return a list of index files where the string could be found.
-    pub fn index_files_for(&self, query: &str) -> Vec<IndexFile> {
+    pub fn index_files_for(&self, query: &str) -> Vec<IndexFile<MAX_BUFFER>> {
         indices_of::<{ LENGTH }, { DEPTH }>(query.as_bytes())
             .map(|key| {
                 // We could cache the index files, but that would create all sorts of race conditions.
@@ -24,7 +60,7 @@ impl<const LENGTH: usize, const DEPTH: usize> IndexCollection<LENGTH, DEPTH> {
                 // Since we are just searching for the index, performance should not be a concern.
                 (
                     key.clone(),
-                    path_for_key(&key, &self.dir).and_then(IndexFile::from_path),
+                    path_for_key(&key, &self.dir).and_then(IndexFile::<{ MAX_BUFFER }>::from_path),
                 )
             })
             .filter_map(|(key, result)| match result {
@@ -42,7 +78,38 @@ impl<const LENGTH: usize, const DEPTH: usize> IndexCollection<LENGTH, DEPTH> {
     }
 
     /// Search for a query in the whole index collection.
-    pub fn find_lines_containing(&self, query: &str, search_style: SearchStyle) -> HashSet<String> {
+    pub fn find_lines_containing(
+        &self,
+        query: &str,
+        search_style: SearchStyle,
+    ) -> IndexCollectionReturn {
+        #[cfg(feature = "lru")]
+        {
+            if let Some(cache_hit) = self
+                .cache
+                .write()
+                .map(|mut cache| cache.get(query).cloned())
+                .unwrap_or_else(
+                    // A cache is just a cache; if it's poisoned, we'll just reset it.
+                    |mut err| reset_cache_on_poisoned(&self.cache, &mut err),
+                )
+            {
+                crate::debug!(
+                    target: LOG_TARGET,
+                    "Cache hit for {query:?} in the index collection, returning {count} cached result.",
+                    query = query,
+                    count = cache_hit.len()
+                );
+                return cache_hit;
+            }
+
+            crate::debug!(
+                target: LOG_TARGET,
+                "Cache miss for {query:?} in the index collection.",
+                query = query
+            );
+        }
+
         crate::debug!(
             target: LOG_TARGET,
             "Searching for {query:?} in the index collection...",
@@ -53,7 +120,7 @@ impl<const LENGTH: usize, const DEPTH: usize> IndexCollection<LENGTH, DEPTH> {
 
         let chunks_count = usize::max(1, usize::min(index_files.len(), rayon::max_num_threads()));
 
-        index_files
+        let results: IndexCollectionReturn = index_files
             .par_chunks(chunks_count)
             .map(|index| {
                 index.iter().try_fold(HashSet::new(), |mut acc, index| {
@@ -89,6 +156,68 @@ impl<const LENGTH: usize, const DEPTH: usize> IndexCollection<LENGTH, DEPTH> {
             })
             .filter_map(|result: io::Result<HashSet<String>>| result.ok())
             .reduce(HashSet::new, |acc, set| acc.union(&set).cloned().collect())
+            .into(); // Convert to an Arc.
+
+        #[cfg(feature = "lru")]
+        {
+            crate::debug!(
+                target: LOG_TARGET,
+                "Caching the {count} results found for key {query:?}.",
+                count = results.len(),
+                query = query
+            );
+            self.cache
+                .write()
+                .map(|mut cache| {
+                    cache.put(query.to_owned(), Arc::clone(&results));
+                })
+                .unwrap_or_else(
+                    // A cache is just a cache; if it's poisoned, we'll just reset it.
+                    |mut err| {
+                        reset_cache_on_poisoned(&self.cache, &mut err);
+                    },
+                );
+        }
+
+        #[cfg(not(feature = "lru"))]
+        {
+            crate::warn!(
+                target: LOG_TARGET,
+                "The search cache is disabled; not caching the {count} results found for key {query:?}.",
+                count = results.len(),
+                query = query
+            );
+        }
+
+        results
+    }
+
+    /// Search for a query in the whole index collection.
+    ///
+    /// This method will return a paginated list of results; the offset and limit
+    /// parameters are used to determine which results to return.
+    ///
+    /// Contrary to `find_lines_containing`, this method will return an owned
+    /// `HashSet` of strings, instead of an `Arc`, since the results won't be reused.
+    ///
+    /// # Note
+    ///
+    /// Since the Lru cache does not persist between calls to the FFI functions,
+    /// this method is not available in the FFI; and is only meaningful when
+    /// the `lru` feature is enabled.
+    pub fn find_lines_containing_paginated(
+        &self,
+        query: &str,
+        search_style: SearchStyle,
+        offset: usize,
+        limit: usize,
+    ) -> HashSet<String> {
+        self.find_lines_containing(query, search_style)
+            .iter()
+            .skip(offset)
+            .take(limit)
+            .cloned()
+            .collect()
     }
 }
 
@@ -138,6 +267,10 @@ mod tests {
                     .map(ToString::to_string)
                     .collect::<HashSet<_>>();
 
+                #[cfg(feature = "lru")]
+                assert_eq!(&expected, actual.as_ref());
+
+                #[cfg(not(feature = "lru"))]
                 assert_eq!(expected, actual);
             }
         };

--- a/src/parse/search/implementations/index_file.rs
+++ b/src/parse/search/implementations/index_file.rs
@@ -3,7 +3,7 @@ use std::{io, path};
 use super::super::{LinesScanner, SearchStyle};
 use crate::{key_for_path, models::IndexFile};
 
-impl IndexFile {
+impl<const MAX_BUFFER: usize> IndexFile<MAX_BUFFER> {
     /// Create an [`IndexFile`] from an existing file.
     ///
     /// This typically is not for creating new files, but for reading existing files.
@@ -65,7 +65,9 @@ mod test {
     use std::collections::HashSet;
 
     use super::*;
-    use crate::{config::TEST_MOCK_INDEX, index_key_path::path_for_key};
+    use crate::{
+        config::MAX_INDEX_BUFFER_SIZE, config::TEST_MOCK_INDEX, index_key_path::path_for_key,
+    };
 
     macro_rules! create_search_test {
         ($name:ident($query:expr, $search_style:expr) == $expected:expr) => {
@@ -73,7 +75,7 @@ mod test {
             fn $name() {
                 let path = path_for_key("pas", TEST_MOCK_INDEX)
                     .expect("Failed to create a path for the key 'pas'.");
-                let index = IndexFile::from_path(&path)
+                let index = IndexFile::<{ MAX_INDEX_BUFFER_SIZE }>::from_path(&path)
                     .expect("The index file for 'pas' could not be found, or could not be read.");
                 let scanner = index
                     .find_lines_containing($query, $search_style)


### PR DESCRIPTION
Not very useful for FFI, as it turns out, as the cache won't persist across FFI calls.