### PR TITLE
feat: move index deduplication into feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ skip_index_write = []
 aho-corasick = ["dep:aho-corasick"]
 regex = ["dep:regex"]
 lru = ["dep:lru"]
+fxhash = ["dep:fxhash"]
+deduplicate = ["fxhash"]
 
 [dependencies]
 aho-corasick = { version = "1.1.3", optional = true }
@@ -29,7 +31,7 @@ anyhow = "1.0.86"
 bloomfilter = "1.0.14"
 clap = { version = "4.5.5", features = ["derive"] }
 env_logger = "0.11.5"
-fxhash = "0.2.1"
+fxhash = { version = "0.2.1", optional = true }
 hashbrown = { version = "0.14.5", features = ["rayon"] }
 kdam = { version = "0.5.2", optional = true }
 log = { version = "0.4.22", features = ["release_max_level_warn", "std"] }

--- a/crates/reader/src/lib.rs
+++ b/crates/reader/src/lib.rs
@@ -1,8 +1,8 @@
 //! The reader coroutine.
 
-mod sync;
-pub use sync::*;
-
 pub mod config;
+mod sync;
 
 pub mod utils;
+
+pub use sync::{ChunkSize, FixedMemoryReader, IterFixedMemoryReader};

--- a/src/parse/models/index_collection.rs
+++ b/src/parse/models/index_collection.rs
@@ -2,7 +2,7 @@
 //!
 
 use hashbrown::HashMap;
-use std::{io, path, sync::RwLock};
+use std::{io, ops::DerefMut, path, sync::RwLock};
 
 use super::{indices_of, IndexFile};
 use crate::config::DEFAULT_MAX_BUFFER;
@@ -80,5 +80,33 @@ impl<const LENGTH: usize, const DEPTH: usize, const MAX_BUFFER: usize>
         } else {
             Ok(false)
         }
+    }
+
+    /// Post-process the collection.
+    fn post_process(&mut self) -> io::Result<()> {
+        let mut new_map = HashMap::default();
+
+        // Swap the indices with a new map, so that we can consume the old map as we
+        // post-process the indices.
+        std::mem::swap(
+            self.indices
+                .write()
+                .expect("Failed to acquire write lock on indices; indices might be poisoned.")
+                .deref_mut(),
+            &mut new_map,
+        );
+
+        new_map
+            .into_iter()
+            .try_for_each(|(_, mut index)| index.post_process())
+    }
+}
+
+impl<const LENGTH: usize, const DEPTH: usize, const MAX_BUFFER: usize> Drop
+    for IndexCollection<LENGTH, DEPTH, MAX_BUFFER>
+{
+    fn drop(&mut self) {
+        self.post_process()
+            .expect("Failed to post-process the index collection.");
     }
 }

--- a/src/parse/models/index_collection.rs
+++ b/src/parse/models/index_collection.rs
@@ -1,7 +1,7 @@
 //! A collection of indices.
 //!
 
-use fxhash::FxHashMap as HashMap;
+use hashbrown::HashMap;
 use std::{io, path, sync::RwLock};
 
 use super::{indices_of, IndexFile};

--- a/src/parse/models/index_file.rs
+++ b/src/parse/models/index_file.rs
@@ -222,6 +222,30 @@ impl<const MAX_SIZE: usize> IndexFile<MAX_SIZE> {
 
         self.flush_buffer(&mut existing_buffer)
     }
+
+    /// Post-process the index.
+    pub fn post_process(&mut self) -> io::Result<()> {
+        crate::debug!(
+            target: LOG_TARGET,
+            "Post-processing the index for '{key}'.",
+            key=self.key,
+        );
+
+        let flushed = self.flush()?;
+
+        crate::debug!(
+            target: LOG_TARGET,
+            "Flushed {flushed} bytes for '{key}'.",
+            key=self.key,
+            flushed=flushed,
+        );
+
+        // TODO Add per-file deduplication here.
+        #[cfg(not(feature = "deduplicate"))]
+        {}
+
+        Ok(())
+    }
 }
 
 impl<const MAX_SIZE: usize> Drop for IndexFile<MAX_SIZE> {

--- a/src/parse/models/index_file.rs
+++ b/src/parse/models/index_file.rs
@@ -6,8 +6,11 @@ use std::{
 };
 
 use crate::{config::DEFAULT_MAX_BUFFER, path_for_key};
+
+#[cfg(feature = "deduplicate")]
 use hashbrown::HashSet;
 
+#[cfg(feature = "deduplicate")]
 type FxHashSet32<T> = HashSet<T, std::hash::BuildHasherDefault<fxhash::FxHasher32>>;
 
 /// A buffer for an index file, for a specific key.
@@ -28,7 +31,10 @@ pub struct IndexFile<const MAX_BUFFER: usize = DEFAULT_MAX_BUFFER> {
     /// [`IndexFile`].
     pub(crate) key: String,
     pub(crate) dir: path::PathBuf,
+
+    #[cfg(feature = "deduplicate")]
     pub(crate) seen: Mutex<FxHashSet32<Vec<u8>>>,
+
     pub(crate) buffer: Mutex<Vec<u8>>,
 }
 
@@ -53,14 +59,20 @@ impl<const MAX_SIZE: usize> IndexFile<MAX_SIZE> {
             key=key,
             dir=dir.as_ref(),
         );
+
+        #[cfg(feature = "deduplicate")]
         let seen = FxHashSet32::default().into();
+
         let buffer = Vec::with_capacity(DEFAULT_MAX_BUFFER).into();
 
         fs::create_dir_all(&dir)?;
         Ok(Self {
             key,
             dir: dir.as_ref().to_owned(),
+
+            #[cfg(feature = "deduplicate")]
             seen,
+
             buffer,
         })
     }
@@ -90,6 +102,7 @@ impl<const MAX_SIZE: usize> IndexFile<MAX_SIZE> {
         }
     }
 
+    #[cfg(feature = "deduplicate")]
     /// Checks if the key is in the index.
     pub fn contains(&self, key: &Vec<u8>) -> bool {
         self.seen
@@ -107,6 +120,7 @@ impl<const MAX_SIZE: usize> IndexFile<MAX_SIZE> {
     ///
     /// Returns `true` if the the set already contains the value;
     /// otherwise it is inserted, and `false` is returned.
+    #[cfg(feature = "deduplicate")]
     pub fn contains_or_set(&self, key: Vec<u8>) -> bool {
         !self
             .seen
@@ -127,47 +141,48 @@ impl<const MAX_SIZE: usize> IndexFile<MAX_SIZE> {
     ///
     /// Returns `true` if the key was added, and `false` if it was already in the index.
     pub fn add(&self, item: Vec<u8>) -> io::Result<bool> {
-        if !self.contains_or_set(item.clone()) {
-            crate::debug!(
-                target: LOG_TARGET,
-                "Adding the item '{item}' to the index for '{key}'.",
-                item=String::from_utf8_lossy(&item),
-                key=self.key,
-            );
-
-            let mut buffer = self.buffer.lock().unwrap_or_else(|_| {
-                panic!(
-                    "The buffer for '{key}' is poisoned; could not continue.",
-                    key = self.key
-                )
-            });
-            let _flushed = if buffer.len() + item.len() + 1 > MAX_SIZE {
-                crate::debug!(
-                    target: LOG_TARGET,
-                    "The buffer for '{key}' is full at {size} bytes; flushing to file.",
-                    key=self.key,
-                    size=buffer.len(),
-                );
-
-                // The buffer is full; flush it to the file.
-                self.flush_buffer(&mut buffer)?
-            } else {
-                0
-            };
-
-            // This key is new.
-            buffer.extend_from_slice(&item);
-            buffer.push(b'\n');
-
-            Ok(true)
-        } else {
+        #[cfg(feature = "deduplicate")]
+        if self.contains_or_set(item.clone()) {
             crate::debug!(
                 "The key '{item}' is already in the index for '{prefix}', skipping.",
                 item = String::from_utf8_lossy(&item),
                 prefix = self.key,
             );
-            Ok(false)
+            return Ok(false);
         }
+
+        crate::debug!(
+            target: LOG_TARGET,
+            "Adding the item '{item}' to the index for '{key}'.",
+            item=String::from_utf8_lossy(&item),
+            key=self.key,
+        );
+
+        let mut buffer = self.buffer.lock().unwrap_or_else(|_| {
+            panic!(
+                "The buffer for '{key}' is poisoned; could not continue.",
+                key = self.key
+            )
+        });
+        let _flushed = if buffer.len() + item.len() + 1 > MAX_SIZE {
+            crate::debug!(
+                target: LOG_TARGET,
+                "The buffer for '{key}' is full at {size} bytes; flushing to file.",
+                key=self.key,
+                size=buffer.len(),
+            );
+
+            // The buffer is full; flush it to the file.
+            self.flush_buffer(&mut buffer)?
+        } else {
+            0
+        };
+
+        // This key is new.
+        buffer.extend_from_slice(&item);
+        buffer.push(b'\n');
+
+        Ok(true)
     }
 
     /// Flushes the provided buffer to the file, and returns the number of bytes written.
@@ -248,6 +263,8 @@ mod test {
             for i in 0..256 {
                 let key = format!("test_{:03}", i).as_bytes().to_vec();
                 index.add(key.clone()).unwrap();
+
+                #[cfg(feature = "deduplicate")]
                 assert!(index.contains(&key));
             }
 
@@ -298,6 +315,8 @@ mod test {
                 );
                 for key in chunk {
                     index.add(key.clone()).unwrap();
+
+                    #[cfg(feature = "deduplicate")]
                     assert!(index.contains(key));
                 }
             });

--- a/src/parse/search/implementations/index_file.rs
+++ b/src/parse/search/implementations/index_file.rs
@@ -37,6 +37,8 @@ impl<const MAX_BUFFER: usize> IndexFile<MAX_BUFFER> {
                     )
                 })?
                 .to_path_buf(),
+
+            #[cfg(feature = "deduplicate")]
             seen: Default::default(),
             buffer: Default::default(),
         })


### PR DESCRIPTION
`HashSet`s for large `IndexFile` is consuming a lot of memory; we shall do that in post processing instead.